### PR TITLE
Upgrade phpcs version to 3.3.0 from 3.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMPOSER_IMAGE="composer:1.6.4"
 ARG BASE_IMAGE="php:7.2-alpine"
 ARG PACKAGIST_NAME="squizlabs/php_codesniffer"
 ARG PHPQA_NAME="phpcs"
-ARG VERSION="3.2.3"
+ARG VERSION="3.3.0"
 
 # Download with Composer - https://getcomposer.org/
 


### PR DESCRIPTION
As PHP_CodeSniffer v3.3.0 was released 5 days ago, I would like to provide the docker image `phpqa/phpcs:3.3.0` that corresponds to PHP_CodeSniffer v3.3.0.

- [Release 3.3.0 · squizlabs/PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.3.0)

_The test results in my local environment_

<img width="897" alt="__desktop_phpcs__ssh_" src="https://user-images.githubusercontent.com/855338/41275556-36fea5de-6e5c-11e8-9215-e24653ed6846.png">
